### PR TITLE
feat: allow matching controllers without prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 [Stimulus HMR plugin]: https://github.com/ElMassimo/vite-plugin-stimulus-hmr
 
+## Unpublished
+
+- Allow matching controllers without prefix in sidecar directories (fix #3).
+
 ## stimulus-vite-helpers 1.0.4 (2021-05-24)
 
 - Fix regexp to avoid namespacing controllers incorrectly (fix #1).

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import type { Application, Definition } from '@hotwired/stimulus'
 import type { ImportedModules, Entry } from './types'
 
-export const CONTROLLER_FILENAME_REGEX = /^(?:.*?(?:controllers|components)\/|\.?\.\/)?(.+)(?:[_-]controller\..+?)$/
+export const CONTROLLER_FILENAME_REGEX = /^(?:.*?(?:controllers|components)\/|\.?\.\/)?(.+)(?:[/_-]controller\..+?)$/
 
 export function registerControllers (application: Application, controllerModules: ImportedModules) {
   application.load(definitionsFromGlob(controllerModules))

--- a/tests/glob.spec.ts
+++ b/tests/glob.spec.ts
@@ -7,6 +7,7 @@ const withoutDefaultExport = { }
 
 const modules = {
   '../components/home_controller.js': mod,
+  '../components/page/controller.js': mod,
   '../controllers/hello_controller.js': mod,
   '../controllers/image/reveal_controller.js': mod,
   './controllers/dashboard_controller.ts': mod,
@@ -18,6 +19,7 @@ const modules = {
 test('definitionsFromGlob', () => {
   expect(definitionsFromGlob(modules)).toEqual([
     { identifier: 'home', controllerConstructor },
+    { identifier: 'page', controllerConstructor },
     { identifier: 'hello', controllerConstructor },
     { identifier: 'image--reveal', controllerConstructor },
     { identifier: 'dashboard', controllerConstructor },


### PR DESCRIPTION
Fixes #3 

Allows matching controllers like `components/page/controller.js`, which were previously ignored, as an underscore `_` or dash `-` before the `controller.(js|ts)` was expected. Now slashes are also allowed 🙃 