### PR TITLE
Update controller identifier generator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import type { Application, Definition } from '@hotwired/stimulus'
 import type { ImportedModules, Entry } from './types'
 
-export const CONTROLLER_FILENAME_REGEX = /^(?:.*?(?:controllers|components)\/|\.?\.\/)?(.+)(?:[/_-]controller\..+?)$/
+export const CONTROLLER_FILENAME_REGEX = /^(?:.*?(?:controllers|components|views)\/|\.?\.\/)?(.+)(?:[/_-]controller\..+?)$/
 
 export function registerControllers (application: Application, controllerModules: ImportedModules) {
   application.load(definitionsFromGlob(controllerModules))
@@ -21,5 +21,5 @@ function definitionFromEntry ([name, controllerModule]: Entry<ImportedModules>):
 export function identifierForGlobKey (key: string): string | undefined {
   const logicalName = (key.match(CONTROLLER_FILENAME_REGEX) || [])[1]
   if (logicalName)
-    return logicalName.replace(/_/g, '-').replace(/\//g, '--')
+    return logicalName.replace(/[^\p{L}\p{N}]/gu, '-')
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,5 +21,5 @@ function definitionFromEntry ([name, controllerModule]: Entry<ImportedModules>):
 export function identifierForGlobKey (key: string): string | undefined {
   const logicalName = (key.match(CONTROLLER_FILENAME_REGEX) || [])[1]
   if (logicalName)
-    return logicalName.replace(/[^\p{L}\p{N}]/gu, '-')
+    return logicalName.replace(/[^\p{L}\p{N}]+/gu, '-')
 }

--- a/tests/glob.spec.ts
+++ b/tests/glob.spec.ts
@@ -14,6 +14,7 @@ const modules = {
   './controllers/fake_controller.ts': withoutDefaultExport,
   './image/reveal_controller.ts': mod,
   '../image/blur_controller.ts': mod,
+  './views/users/orders/index_controller.ts': mod,
 }
 
 test('definitionsFromGlob', () => {
@@ -21,9 +22,10 @@ test('definitionsFromGlob', () => {
     { identifier: 'home', controllerConstructor },
     { identifier: 'page', controllerConstructor },
     { identifier: 'hello', controllerConstructor },
-    { identifier: 'image--reveal', controllerConstructor },
+    { identifier: 'image-reveal', controllerConstructor },
     { identifier: 'dashboard', controllerConstructor },
-    { identifier: 'image--reveal', controllerConstructor },
-    { identifier: 'image--blur', controllerConstructor },
+    { identifier: 'image-reveal', controllerConstructor },
+    { identifier: 'image-blur', controllerConstructor },
+    { identifier: 'users-orders-index', controllerConstructor }
   ])
 })


### PR DESCRIPTION
Breaking change: all joint and single non-alphanumeric (unicode) characters in file path will be replaced with '-'.
And also:
- adds support for unicode characters in file paths
- adds support for `views` folder in file paths

Discussion: https://github.com/hotwired/stimulus/issues/639