### PR TITLE
Use `@hotwired/stimulus` NPM package in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npx ni stimulus-vite-helpers
 You can now register your Stimulus controllers using Vite's [import.meta.glob] and the `registerControllers` helper:
 
 ```ts
-import { Application } from 'stimulus'
+import { Application } from '@hotwired/stimulus'
 import { registerControllers } from 'stimulus-vite-helpers'
 
 const application = Application.start()


### PR DESCRIPTION
This pull request updates the README to use the `@hotwired/stimulus` NPM package over the "old" `stimulus` package.